### PR TITLE
BUG: update test to use new label map class

### DIFF
--- a/Util/LabelToDICOMSEGConverter/Testing/Python/LabelToDICOMSEGConverterSelfTest.py
+++ b/Util/LabelToDICOMSEGConverter/Testing/Python/LabelToDICOMSEGConverterSelfTest.py
@@ -377,28 +377,27 @@ class LabelToDICOMSEGConverterSelfTestTest(unittest.TestCase):
       self.delayDisplay('Wait',10000)
 
       dicomWidget.detailsPopup.loadCheckedLoadables()
-      volumes = slicer.util.getNodes('vtkMRMLScalarVolumeNode*')
+      volumes = slicer.util.getNodes('vtkMRMLLabelMapVolumeNode*')
       for n,v in volumes.items():
-        print('Volume found: '+v.GetID())
-      self.assertTrue(len(volumes) == 2)
-      
+        print('Label volume found: '+v.GetID())
+      self.assertTrue(len(volumes) == 1)
+
       for name,volume in volumes.items():
-        if volume.GetAttribute('Label') == '1':
-          image = volume.GetImageData()
-          previousImage = thresh.GetOutput()
-          diff = vtk.vtkImageDifference()
-          if vtk.vtkVersion().GetVTKMajorVersion() < 6:
-            diff.SetInput(thresh.GetOutput())
-          else:
-            diff.SetInputData(thresh.GetOutput())
-          diff.SetImage(image)
-          diff.Update()
-          if diff.GetThresholdedError() > 1:
-            self.delayDisplay('Reloaded image does not match')
-            self.assertTrue(False)
+        image = volume.GetImageData()
+        previousImage = thresh.GetOutput()
+        diff = vtk.vtkImageDifference()
+        if vtk.vtkVersion().GetVTKMajorVersion() < 6:
+          diff.SetInput(thresh.GetOutput())
+        else:
+          diff.SetInputData(thresh.GetOutput())
+        diff.SetImage(image)
+        diff.Update()
+        if diff.GetThresholdedError() > 1:
+          self.delayDisplay('Reloaded image does not match')
+          self.assertTrue(False)
 
       self.delayDisplay('Test passed')
-      
+
       self.delayDisplay("Restoring original database directory")
       if self.originalDatabaseDirectory:
         dicomWidget.onDatabaseDirectoryChanged(self.originalDatabaseDirectory)


### PR DESCRIPTION
The test was getting all the scalar volumes and checking for the
label attribute, but the change to use a new class, vtkMRMLLabelMapVolumeNode,
meant that the sought after label file was not being found to check.
This change updates the test to get just the label maps in the scene and
to test that there is one and it is correct.