### PR TITLE
ENH: add color table and terminology for DICOM segmentation reading

### DIFF
--- a/Logic/vtkSlicerReportingModuleLogic.h
+++ b/Logic/vtkSlicerReportingModuleLogic.h
@@ -141,7 +141,10 @@ public:
   bool IsDicomSeg(const std::string fname);
   // TODO: consider taking report as as a parameter here?
   std::string DicomSegWrite(vtkCollection* labelNodes, const std::string dirname, bool saveReferencedDcm = false);
-  bool DicomSegRead(vtkCollection*, const std::string fname, vtkMRMLColorNode* colorNode = NULL);
+  /// Reads in the DICOM Segmentation object from the given file name, creates a series of NRRD
+  /// label map volume files in the temporary output directory, as well as information files with
+  /// the segmentation information.
+  bool DicomSegRead(vtkCollection*, const std::string fname);
 
   /// set/get the error string
   vtkGetMacro(ErrorMessage, std::string);


### PR DESCRIPTION
When reading in a DICOM segmentatin file, create one color table node
for all the segments, and build up a terminology associated with the
segmentation from the .info files.
Adjusted the logic call to not use the color node, do the terminology and color
information file parsing in the segmentation plugin.
Added a check that the SEG2NRRD CLI was loaded to prevent a crash if Slicer was started up
without CLI modules.

Issue #52