### PR TITLE
ENH: Add terminology region support, fix color display

### DIFF
--- a/SEGSupport/SEG2NRRD.cxx
+++ b/SEGSupport/SEG2NRRD.cxx
@@ -337,7 +337,7 @@ int main(int argc, char *argv[])
           index[0] = col;
           index[1] = row;
           index[2] = slice;
-          segment2image[segmentId]->SetPixel(index, 1);
+          segment2image[segmentId]->SetPixel(index, segmentId);
         }
       }
     }


### PR DESCRIPTION
After updates to the Slicer topic branch in naucoin
4047-Add-semantic-color-information-to-color-selector-in-editor
parse out and set the region information read from the segmentation object. Take
into account that the modifier lines may be omitted in the .info file, refer
to SEG2NRRD for the calls that do the writing.
Updated SEG2NRRD to set the label map pixel values to the segmentation number
rather than always using 1. This allows the colors to display properly with one
color node rather than having to define a color node per segmentation.

Issue #52