### PR TITLE
ENH: update to use new terminology methods, order

### DIFF
--- a/Py/SEGExporterSelfTest.py
+++ b/Py/SEGExporterSelfTest.py
@@ -230,26 +230,44 @@ class SEGExporterSelfTestTest(ScriptedLoadableModuleTest):
       structureName = nodeName[len(masterName)+1:-1*len('-label')]
       labelIndex = colorNode.GetColorIndexByName( structureName )
 
-      category = colorLogic.GetCategoryFromLabel(labelIndex, terminologyName)
-      categoryType = colorLogic.GetCategoryTypeFromLabel(labelIndex, terminologyName)
-      categoryModifier = colorLogic.GetCategoryModifierFromLabel(labelIndex, terminologyName)
+      # get the attributes and conver to format CodeValue,CodeMeaning,CodingSchemeDesignator
+      # or empty strings if not defined
+      propertyCategoryWithColons = colorLogic.GetSegmentedPropertyCategory(labelIndex, terminologyName)
+      if propertyCategoryWithColons == '':
+        print 'ERROR: no segmented property category found for label ',str(labelIndex)
+        # Try setting a default as this section is required
+        propertyCategory = "C94970,NCIt,Reference Region"
+      else:
+        propertyCategory = propertyCategoryWithColons.replace(':',',')
 
-      propertyCategory = colorLogic.GetCategoryTypeCodeFromLabel(labelIndex, terminologyName)
-      propertyCategory += "," + colorLogic.GetCategorySchemeFromLabel(labelIndex, terminologyName)
-      propertyCategory += "," + colorLogic.GetCategoryFromLabel(labelIndex, terminologyName)
+      propertyTypeWithColons = colorLogic.GetSegmentedPropertyType(labelIndex, terminologyName)
+      propertyType = propertyTypeWithColons.replace(':',',')
+
+      propertyTypeModifierWithColons = colorLogic.GetSegmentedPropertyTypeModifier(labelIndex, terminologyName)
+      propertyTypeModifier = propertyTypeModifierWithColons.replace(':',',')
+
+      anatomicRegionWithColons = colorLogic.GetAnatomicRegion(labelIndex, terminologyName)
+      anatomicRegion = anatomicRegionWithColons.replace(':',',')
+
+      anatomicRegionModifierWithColons = colorLogic.GetAnatomicRegionModifier(labelIndex, terminologyName)
+      anatomicRegionModifier = anatomicRegionModifierWithColons.replace(':',',')
+
 
       structureFileName = structureName + str(random.randint(0,vtk.VTK_INT_MAX)) + ".txt"
       filePath = os.path.join(slicer.app.temporaryPath, structureFileName)
 
+      # EncodeSEG is expecting a file of format:
+      # labelNum;SegmentedPropertyCategory:codeValue,codeScheme,codeMeaning;SegmentedPropertyType:v,m,s etc
       attributes = "%d" % labelIndex
-      attributes += ";"+propertyCategory
-      if False:
-        # requires access from colorLogic
-        attributes += ";SegmentedPropertyType:" + categoryType
-      else:
-        attributes += ";SegmentedPropertyType:" + "C94970,NCIt,Reference Region"
-      if categoryModifier != "":
-        attributes += ";AnatomicRegionModifer:" + categoryModifier
+      attributes += ";SegmentedPropertyCategory:"+propertyCategory
+      if propertyType != "":
+        attributes += ";SegmentedPropertyType:" + propertyType
+      if propertyTypeModifier != "":
+        attributes += ";SegmentedPropertyTypeModifier:" + propertyTypeModifier
+      if anatomicRegion != "":
+        attriutes += ";AnatomicRegion:" + anatomicRegion
+      if anatomicRegionModifier != "":
+        attributes += ";AnatomicRegionModifer:" + anatomicRegionModifier
       attributes += ";SegmentAlgorithmType:AUTOMATIC"
       attributes += ";SegmentAlgorithmName:SlicerSelfTest"
       fp = open(filePath, "w")

--- a/SEGSupport/SEG2NRRD.cxx
+++ b/SEGSupport/SEG2NRRD.cxx
@@ -265,45 +265,46 @@ int main(int argc, char *argv[])
         std::cout << rgb[i] << " ";
       std::cout << std::endl;
 
-      metastr << "RGBColor:" << rgb[0] << "," << rgb[1] << "," << rgb[2] << std::endl;
+      // line format:
+      // labelNum;RGB:R,G,B;SegmentedPropertyCategory:code,scheme,meaning;SegmentedPropertyType:code,scheme,meaning;SegmentedPropertyTypeModifier:code,scheme,meaning;AnatomicRegion:code,scheme,meaning;AnatomicRegionModifier:code,scheme,meaning
+      metastr << segmentId;
+      metastr << ";RGB:" << rgb[0] << "," << rgb[1] << "," << rgb[2];
 
-      // get anatomy codes
       OFString meaning, designator, code;
-      GeneralAnatomyMacro &anatomyMacro = segment->getGeneralAnatomyCode();
-      anatomyMacro.getAnatomicRegion().getCodeMeaning(meaning);
-      anatomyMacro.getAnatomicRegion().getCodeValue(code);
-      anatomyMacro.getAnatomicRegion().getCodingSchemeDesignator(designator);
-      std::cout << "Anatomic region meaning: " << meaning << std::endl;
-      metastr << "AnatomicRegion:" << code << "," << designator << "," << meaning << std::endl;
-      if(anatomyMacro.getAnatomicRegionModifier().size()>0){
-        anatomyMacro.getAnatomicRegionModifier()[0]->getCodeMeaning(meaning);
-        anatomyMacro.getAnatomicRegionModifier()[0]->getCodeValue(code);
-        anatomyMacro.getAnatomicRegionModifier()[0]->getCodingSchemeDesignator(designator);
-        std::cout << "  Modifier: " << code << std::endl;
-        metastr << "AnatomicRegionModifier:" << code << "," << designator << "," << meaning << std::endl;
-      }
-
-      OFString categoryMeaning;
       segment->getSegmentedPropertyCategoryCode().getCodeMeaning(meaning);
       segment->getSegmentedPropertyCategoryCode().getCodeValue(code);
       segment->getSegmentedPropertyCategoryCode().getCodingSchemeDesignator(designator);
-      metastr << "SegmentedPropertyCategory:" << code << ","  << designator << "," << meaning << std::endl;
-      std::cout << "SegmentedPropertyCategory: " << meaning << std::endl;
+      std::cout << "SegmentedPropertyCategory: " << meaning;
+      metastr << ";SegmentedPropertyCategory:" << code << ","  << designator << "," << meaning;
 
-      OFString typeMeaning, typeModifierMeaning;
       segment->getSegmentedPropertyTypeCode().getCodeMeaning(meaning);
       segment->getSegmentedPropertyTypeCode().getCodeValue(code);
       segment->getSegmentedPropertyTypeCode().getCodingSchemeDesignator(designator);
       std::cout << "Type meaning: " << meaning << std::endl;
-      metastr << "SegmentedPropertyType:" << code << "," << designator << "," << meaning << std::endl;
+      metastr << ";SegmentedPropertyType:" << code << "," << designator << "," << meaning;
       if(segment->getSegmentedPropertyTypeModifierCode().size()>0){
         segment->getSegmentedPropertyTypeModifierCode()[0]->getCodeMeaning(meaning);
         segment->getSegmentedPropertyTypeModifierCode()[0]->getCodeValue(code);
         segment->getSegmentedPropertyTypeModifierCode()[0]->getCodingSchemeDesignator(designator);
         std::cout << "  Modifier: " << meaning << std::endl;
-        metastr << "SegmentedPropertyTypeModifier:" << code << "," << designator << "," << meaning << std::endl;
+        metastr << ";SegmentedPropertyTypeModifier:" << code << "," << designator << "," << meaning;
       }
 
+      // get anatomy codes
+      GeneralAnatomyMacro &anatomyMacro = segment->getGeneralAnatomyCode();
+      anatomyMacro.getAnatomicRegion().getCodeMeaning(meaning);
+      anatomyMacro.getAnatomicRegion().getCodeValue(code);
+      anatomyMacro.getAnatomicRegion().getCodingSchemeDesignator(designator);
+      std::cout << "Anatomic region meaning: " << meaning << std::endl;
+      metastr << ";AnatomicRegion:" << code << "," << designator << "," << meaning;
+      if(anatomyMacro.getAnatomicRegionModifier().size()>0){
+        anatomyMacro.getAnatomicRegionModifier()[0]->getCodeMeaning(meaning);
+        anatomyMacro.getAnatomicRegionModifier()[0]->getCodeValue(code);
+        anatomyMacro.getAnatomicRegionModifier()[0]->getCodingSchemeDesignator(designator);
+        std::cout << "  Modifier: " << code << std::endl;
+        metastr << ";AnatomicRegionModifier:" << code << "," << designator << "," << meaning;
+      }
+      metastr << std::endl;
       segment2meta[segmentId] = metastr.str();
     }
 


### PR DESCRIPTION
Update the plugin to use the new order of terms when adding a term to
a terminology.
Update the SEG exporter self test to use the new color logic methods,

Depends on Nov 12/15 update to:
https://github.com/naucoin/Slicer/tree/4047-Add-semantic-color-information-to-color-selector-in-editor

Unify terminology file formats:
Update SEG2NRRD.cxx to use the format from EncodeSEG.cxx.
Update DICOMSegmentationPlugin.py to parse the single line
format, with the capability to deal with multiple lines defining
terminology for different labels in one file.

Issue #52
